### PR TITLE
change emojidir to ~/.cache/shmoji

### DIFF
--- a/shmoji
+++ b/shmoji
@@ -11,7 +11,7 @@
 set -e
 
 cmd="$1"
-emojidir="$HOME/.local/share/shmoji"
+emojidir="$HOME/.cache/shmoji"
 emojifile="$emojidir/emojis.txt"
 
 die() {


### PR DESCRIPTION
The rationale is `.cache` seems better suited for a file that's not meant to be ever edited but merely downloaded from a source as a reference file. Like `.local/share`, `.cache` is defined by Freedesktop XDG Base Directory Specification. The environment variable should be `$XDG_CACHE_HOME`.