### PR TITLE
feat: wmenu support

### DIFF
--- a/README
+++ b/README
@@ -6,7 +6,7 @@ demo: https://asciinema.org/a/525695
 
 
 $ shmoji -h
-usage: [download | bemenu | rofi | fzf]
+usage: [download | bemenu | dmenu | rofi | wmenu | fzf]
 
 examples:
   # download emojis
@@ -21,6 +21,9 @@ examples:
   # launch shmoji with rofi
   shmoji rofi
 
+  # launch shmoji with wmenu
+  shmoji wmenu
+
   # launch shmoji with wofi
   shmoji wofi
 
@@ -30,7 +33,7 @@ examples:
 
 how do i use this in...
 sway:
-  bindsym $mod+Shift+o exec --no-startup-id shmoji bemenu
+  bindsym $mod+Shift+o exec --no-startup-id shmoji wmenu
 
 i3:
   bindsym $mod+Shift+o exec --no-startup-id shmoji rofi

--- a/shmoji
+++ b/shmoji
@@ -39,7 +39,7 @@ case "$cmd" in
     download)
         depends curl
         mkdir -p "$emojidir"
-        # $ wc -l /var/www/trash.j3s.sh/emojis.txt 
+        # $ wc -l /var/www/trash.j3s.sh/emojis.txt
         # 3570 /var/www/trash.j3s.sh/emojis.txt
         curl 'https://trash.j3s.sh/emojis.txt' >"$emojifile"
         ;;
@@ -61,6 +61,12 @@ case "$cmd" in
         win=$(xdotool getactivewindow)
         emoji=$(cat "$emojifile" | rofi -dmenu | cut -d " " -f 1 | tr -d '\n')
         [ "$emoji" ] && xdotool windowactivate --sync $win type --clearmodifiers $emoji
+        ;;
+    wmenu)
+        emojicheck
+        depends wmenu wl-copy
+        emoji=$(cat "$emojifile" | wmenu)
+        emojiprint "$emoji" | wl-copy
         ;;
     wofi)
       emojicheck


### PR DESCRIPTION
Hi, it me again!

wmenu is the new default menu for Sway: https://github.com/swaywm/sway/releases/tag/1.9

I actually wasn’t sure whether to go with `wtype` or `wl-copy`; the existing code base is somewhat inconsistent. I prefer the clipboard approach but I can change it if necessary.